### PR TITLE
Update cron-tasks.sh

### DIFF
--- a/scripts/cron-tasks.sh
+++ b/scripts/cron-tasks.sh
@@ -26,7 +26,7 @@ fi
 cd /cron-scripts
 for script in *.sh; do
     echo "> Running Script: $script"
-    docker exec $exec_user -i "$containerId" bash < $script
+    docker exec -u $exec_user -i "$containerId" bash < $script
 done
 
 echo "> Done"


### PR DESCRIPTION
docker exec needs parameter "-u" to run script in correct user environment and not to specify user as container name.