### PR TITLE
apk add docker-cli instead of docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --no-cache docker bash tini
+RUN apk add --no-cache docker-cli bash tini
 
 ENV NEXTCLOUD_EXEC_USER=www-data
 ENV NEXTCLOUD_CONTAINER_NAME=


### PR DESCRIPTION
Hello rcdailey, I'm a fan of your nextcloud-cronjob image and have been using it for the better part of a year for my own nextcloud deployment.

In developing my own container image (for simplifying/automating nextcloud data and database backups) I learned that for my purposes I can "apk add docker-cli" instead of "apk add docker".

I think this could be of benefit for nextcloud-cronjob.  As far as I can tell, the only reason to add docker is to use docker exec to run the cron.php script.

I have tested this change and it appears to run fine.  The benefit on my system is an image reduction from 324MB down to 83MB.

This is my first pull request so I'd be greatful for any feedback!