### PR TITLE
fix: only return one container when searching

### DIFF
--- a/scripts/find-container.sh
+++ b/scripts/find-container.sh
@@ -10,7 +10,8 @@ fi
 
 containerName="${containerName}${NEXTCLOUD_CONTAINER_NAME}"
 
-# Get the ID of the container so we can exec something in it later
+# Get the ID of the first matching container so we can exec something in it later
 docker ps --format '{{.Names}},{{.ID}}' | \
     egrep "^${containerName}${matchEnd}" | \
-    awk '{split($0,a,","); print a[2]}'
+    awk '{split($0,a,","); print a[2]}' | \
+    head -n 1


### PR DESCRIPTION
You can have multiple containers next to each others, especially if you're using a reverse proxy and a load balancer to spread the load

Fix #21 